### PR TITLE
Support fat gem for Windows

### DIFF
--- a/libyajl2.gemspec
+++ b/libyajl2.gemspec
@@ -13,7 +13,8 @@ Gem::Specification.new do |spec|
   spec.homepage      = "https://github.com/opscode/libyajl2-gem"
   spec.licenses       = ["Apache 2.0"]
 
-  spec.files         = Dir.glob("{ext,lib,spec}/**/*") +
+  spec.files         = Dir.glob("{ext,lib,spec}/**/*") -
+    Dir.glob("lib/libyajl2/vendored-libyajl2/**/*") +
     %w{Gemfile Rakefile CONTRIBUTING.md README.md libyajl2.gemspec bootstrap.sh LICENSE}
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^spec/})
@@ -26,6 +27,9 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake"
   # rake-compiler 0.9.2 is required for rbx compiles, and in turn requires rubygems >= 1.8.25
   spec.add_development_dependency "rake-compiler", "~> 0.9"
+  spec.add_development_dependency "rake-compiler-dock", "~> 0.5"
+  # pin mime-types in order to work on ruby 1.8.7
+  spec.add_development_dependency "mime-types", "~> 1.16"
   spec.add_development_dependency "rspec", "~> 2.14"
   spec.add_development_dependency "ffi", "~> 1.9"
 end


### PR DESCRIPTION
If libyajl2 provides fat gems (gems that include binary), Windows users don't need to install DevKit. It'll be easy to install.

Could you provide fat gems?

With this change, we can build fat gems for Windows by the following command:

```
rake gem:windows
```

The above command requires Docker to build binaries for Windows. It uses [rake-compiler-dock](https://github.com/rake-compiler/rake-compiler-dock).

Built gems are placed at the followings:
- pkg/libyajl2-#{version}-x86-mingw32.gem
- pkg/libyajl2-#{version}-x64-mingw32.gem

Here are fat gems I built:
- http://www.clear-code.com/~kou/libyajl2-1.2.0-x86-mingw32.gem
- http://www.clear-code.com/~kou/libyajl2-1.2.0-x64-mingw32.gem

I confirmed that libyajl2-1.2.0-x64-mingw32.gem works well with ffi-yajl(*) on 64bit Windows 7.

(*) I need to change some codes. I'll send a pull request to ffi-yajl after this pull request is merged.
