### PR TITLE
Escape prefix when generating makefile

### DIFF
--- a/ext/libyajl2/extconf.rb
+++ b/ext/libyajl2/extconf.rb
@@ -1,6 +1,7 @@
 
 require 'rbconfig'
 require 'fileutils'
+require 'shellwords'
 
 if ENV["USE_SYSTEM_LIBYAJL2"]
   File.open("Makefile", "w+") do |f|
@@ -32,7 +33,7 @@ module Libyajl2Build
   end
 
   def self.prefix
-    PREFIX
+    PREFIX.shellescape
   end
 
   def self.deps


### PR DESCRIPTION
Generating the native extensions fails if there's a space in the bundle path:

```
mkdir -p /root/foo bar/vendor/bundle/ruby/2.3.0/gems/libyajl2-1.2.0/lib/libyajl2/vendored-libyajl2/lib
cp libyajl.so /root/foo bar/vendor/bundle/ruby/2.3.0/gems/libyajl2-1.2.0/lib/libyajl2/vendored-libyajl2/lib/libyajl.so
cp: target 'bar/vendor/bundle/ruby/2.3.0/gems/libyajl2-1.2.0/lib/libyajl2/vendored-libyajl2/lib/libyajl.so' is not a directory
Makefile:6: recipe for target 'install' failed
```

Adding `#shellescape` to the prefix when generating the Makefile to resolve this