### PR TITLE
Quote paths in extconf.rb

### DIFF
--- a/ext/libyajl2/extconf.rb
+++ b/ext/libyajl2/extconf.rb
@@ -80,10 +80,10 @@ $(DLLIB): $(OBJS)
 \t$(COMPILE.c) $(OUTPUT_OPTION) $<
 
 install:
-\tmkdir -p #{prefix}/lib
-\tcp $(DLLIB) #{prefix}/lib/$(DLLIB)
-\tmkdir -p #{prefix}/include/yajl
-\tcp yajl/*.h #{prefix}/include/yajl
+\tmkdir -p "#{prefix}/lib"
+\tcp $(DLLIB) "#{prefix}/lib/$(DLLIB)"
+\tmkdir -p "#{prefix}/include/yajl"
+\tcp yajl/*.h "#{prefix}/include/yajl"
 EOF
       end
     else
@@ -115,20 +115,20 @@ EOF
         if windows?
           f.write <<EOF
 install:
-\tmkdir -p #{prefix}/lib
-\tcp libyajl.so #{prefix}/lib/libyajl.so
-\tcp libyajldll.a #{prefix}/lib/libyajldll.a
-\tcp libyajl.def #{prefix}/lib/libyajl.def
-\tmkdir -p #{prefix}/include/yajl
-\tcp yajl/*.h #{prefix}/include/yajl
+\tmkdir -p "#{prefix}/lib"
+\tcp libyajl.so "#{prefix}/lib/libyajl.so"
+\tcp libyajldll.a "#{prefix}/lib/libyajldll.a"
+\tcp libyajl.def "#{prefix}/lib/libyajl.def"
+\tmkdir -p "#{prefix}/include/yajl"
+\tcp yajl/*.h "#{prefix}/include/yajl"
 EOF
         else
           f.write <<EOF
 install:
-\tmkdir -p #{prefix}/lib
-\tcp $(DLLIB) #{prefix}/lib/$(DLLIB)
-\tmkdir -p #{prefix}/include/yajl
-\tcp yajl/*.h #{prefix}/include/yajl
+\tmkdir -p "#{prefix}/lib"
+\tcp $(DLLIB) "#{prefix}/lib/$(DLLIB)"
+\tmkdir -p "#{prefix}/include/yajl"
+\tcp yajl/*.h "#{prefix}/include/yajl"
 EOF
         end
       end


### PR DESCRIPTION
Fixes #22

NOTE: I could use some help with this, because I can't get the existing build and test tasks to succeed on my Macbook :(

Signed-off-by: James Stocks <jstocks@chef.io>

## Description
The make install for this gem fails if the working directory has space characters. This commit adds double quotes around the paths.

## Related Issue
#22

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
