### PR TITLE
fix: rename Windows implib to use .lib extension instead of .a

### DIFF
--- a/ext/libyajl2/extconf.rb
+++ b/ext/libyajl2/extconf.rb
@@ -52,7 +52,7 @@ module Libyajl2Build
 
     # create the implib on windows
     if windows?
-      $LDFLAGS << " -Wl,--export-all-symbols -Wl,--enable-auto-import -Wl,--out-implib=libyajldll.a -Wl,--output-def,libyajl.def"
+      $LDFLAGS << " -Wl,--export-all-symbols -Wl,--enable-auto-import -Wl,--out-implib=libyajldll.lib -Wl,--output-def,libyajl.def"
     end
 
     $CFLAGS << " -DNDEBUG"
@@ -117,7 +117,7 @@ EOF
 install:
 \tmkdir -p #{prefix}/lib
 \tcp libyajl.so #{prefix}/lib/libyajl.so
-\tcp libyajldll.a #{prefix}/lib/libyajldll.a
+\tcp libyajldll.lib #{prefix}/lib/libyajldll.lib
 \tcp libyajl.def #{prefix}/lib/libyajl.def
 \tmkdir -p #{prefix}/include/yajl
 \tcp yajl/*.h #{prefix}/include/yajl


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description

By default, omnibus-software will clean up all *.a files in the Ruby gem path
(https://github.com/chef/omnibus-software/blob/e43f50af2e03dc073174f8de819d08432b9b22b7/config/software/ruby-cleanup.rb#L40-L53).

By convention, Windows implib files should have a .lib extension (https://learn.microsoft.com/en-us/cpp/build/reference/implib-name-import-library?view=msvc-170), so this change makes it possible to preserve the required library.

## Related Issue

https://github.com/chef/ffi-yajl/pull/114

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
